### PR TITLE
Replace `anyhow` with custom error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "anyhow"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,18 +178,18 @@ checksum = "18738c5d4c7fae6727a96adb94722ef7ce82f3eafea0a11777e258a93816537e"
 dependencies = [
  "enumflags2",
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "leucite"
 version = "0.2.0"
 dependencies = [
- "anyhow",
  "landlock",
  "leucite",
  "libc",
  "tempdir",
+ "thiserror 2.0.12",
  "tmpdir",
  "tokio",
 ]
@@ -471,7 +465,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -479,6 +482,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ license = "Apache-2.0"
 default = []
 
 [dependencies]
-anyhow = "1.0.94"
 landlock = "0.4.1"
 libc = "0.2.169"
+thiserror = "2.0.12"
 tokio = { version = "1.42.0", features = ["process", "fs"], optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //!     .wait()?;
 //! # std::io::Result::Ok(())
 //! ```
-use anyhow::Context;
 use landlock::{
     path_beneath_rules, Access, AccessFs, AccessNet, NetPort, Ruleset, RulesetAttr,
     RulesetCreatedAttr, RulesetStatus, ABI,
@@ -39,6 +38,22 @@ pub use prlimit::MemorySize;
 
 #[cfg(not(target_os = "linux"))]
 compile_error!("`leucite` must be run on linux.");
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("setting filesystem access: {source}")]
+    AccessFs { source: landlock::RulesetError },
+    #[error("setting network access: {source}")]
+    AcessNet { source: landlock::RulesetError },
+    #[error("creating ruleset: {source}")]
+    CreateRuleset { source: landlock::RulesetError },
+    #[error("setting bind ports: {source}")]
+    SetBindPorts { source: landlock::RulesetError },
+    #[error("setting connect ports: {source}")]
+    SetConnectPorts { source: landlock::RulesetError },
+    #[error("installed kernel does not support landlock")]
+    LandlockNotSupported,
+}
 
 /// Struct which holds the rules for restrictions.  For more information, see [`Ruleset`].
 ///
@@ -101,15 +116,15 @@ impl Rules {
     }
 
     /// Restrict the current thread using these rules
-    pub fn restrict(&self) -> anyhow::Result<()> {
+    pub fn restrict(&self) -> Result<(), Error> {
         let abi = ABI::V4;
         let rules = Ruleset::default()
             .handle_access(AccessFs::from_all(abi))
-            .context("setting fs access")?
+            .map_err(|source| Error::AccessFs { source })?
             .handle_access(AccessNet::from_all(abi))
-            .context("setting net access")?
+            .map_err(|source| Error::AcessNet { source })?
             .create()
-            .context("creating ruleset")?;
+            .map_err(|source| Error::CreateRuleset { source })?;
 
         let rules = if self.bind_ports.is_empty() {
             rules.add_rule(NetPort::new(0, AccessNet::BindTcp))
@@ -120,7 +135,7 @@ impl Rules {
                     .map(|p| Ok(NetPort::new(*p, AccessNet::BindTcp))),
             )
         }
-        .context("setting bind ports")?;
+        .map_err(|source| Error::SetBindPorts { source })?;
 
         let rules = if self.connect_ports.is_empty() {
             rules.add_rule(NetPort::new(0, AccessNet::ConnectTcp))
@@ -131,36 +146,32 @@ impl Rules {
                     .map(|p| Ok(NetPort::new(*p, AccessNet::ConnectTcp))),
             )
         }
-        .context("setting connect ports")?;
+        .map_err(|source| Error::SetConnectPorts { source })?;
 
         let status = rules
             .add_rules(path_beneath_rules(
                 &self.read_only,
                 AccessFs::from_read(abi),
             ))
-            .context("setting RO paths")?
+            .map_err(|source| Error::AccessFs { source })?
             .add_rules(path_beneath_rules(
                 &self.write_only,
                 AccessFs::from_write(abi),
             ))
-            .context("setting WO paths")?
+            .map_err(|source| Error::AccessFs { source })?
             .add_rules(path_beneath_rules(
                 &self.read_write,
                 AccessFs::from_all(abi),
             ))
-            .context("setting RW paths")?
+            .map_err(|source| Error::AccessFs { source })?
             .restrict_self()
-            .context("creating restrictions")?;
+            .map_err(|source| Error::AccessFs { source })?;
 
         if let RulesetStatus::NotEnforced = status.ruleset {
-            anyhow::bail!("Installed kernel does not support landlock.")
+            return Err(Error::LandlockNotSupported);
         }
         Ok(())
     }
-}
-
-fn anyhow_to_io<T>(res: anyhow::Result<T>) -> io::Result<T> {
-    res.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
 }
 
 /// Extension for [`Command`] or [`tokio::process::Command`] that restricts a command once it is
@@ -230,7 +241,7 @@ macro_rules! impl_cmd {
 impl_cmd! {
     fn restrict(&mut self, rules: Arc<Rules>) -> &mut Self {
         unsafe {
-            self.pre_exec(move || anyhow_to_io(rules.restrict().context("creating restrictions")))
+            self.pre_exec(move || rules.restrict().map_err(|e| io::Error::new(io::ErrorKind::Other, e)))
         }
     }
 


### PR DESCRIPTION
This PR replaces the use of `anyhow` `context` based error handling with a custom `Error` type. This is done to increase compatibility with other error handling libraries (`eyre`, `snafu`, etc).

I tried to replicate most of the error messages into the `#[error(...)]` of each variant, but chose not to create a variant for all error. If you want to add more detail we can do that!